### PR TITLE
fix http to https url converter

### DIFF
--- a/HtmlToAmpConverter/Extensions/string.cs
+++ b/HtmlToAmpConverter/Extensions/string.cs
@@ -15,7 +15,7 @@
         return $"https:{url}";
 
       if (url.StartsWith("http://"))
-        return $"https://{url.Substring(6, url.Length)}";
+        return $"https://{url.Substring(6, url.Length - 6)}";
 
       return url;
 


### PR DESCRIPTION
It throws System.ArgumentOutOfRangeException: 'Index and length must refer to a location within the string. (Parameter 'length')' when trying to convert to Amp html. 

There is the bug with url converter 